### PR TITLE
security fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<java-version>1.6</java-version>
 		<org.springframework-version>4.3.20.RELEASE</org.springframework-version>
-		<org.slf4j-version>1.5.10</org.slf4j-version>
+		<org.slf4j-version>1.7.28</org.slf4j-version>
 		<war.file.name>amenity-editor</war.file.name>
 
 		<db.driver>org.h2.Driver</db.driver>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<java-version>1.6</java-version>
-		<org.springframework-version>4.3.15.RELEASE</org.springframework-version>
+		<org.springframework-version>4.3.18.RELEASE</org.springframework-version>
 		<org.slf4j-version>1.5.10</org.slf4j-version>
 		<war.file.name>amenity-editor</war.file.name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -19,8 +19,8 @@
 		<db.password>sa</db.password>
 
 		<oauth.callbackUrl>http://localhost:8080/amenity-editor/ae/oauth</oauth.callbackUrl>
-		<oauth.consumerKey />
-		<oauth.consumerSecret />
+		<oauth.consumerKey/>
+		<oauth.consumerSecret/>
 
 		<osm.api.base.url>http://api06.dev.openstreetmap.org</osm.api.base.url>
 		<oauth.requestTokenEndpointUrl>http://api06.dev.openstreetmap.org/oauth/request_token</oauth.requestTokenEndpointUrl>
@@ -164,7 +164,7 @@
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>httpclient</artifactId>
-			<version>4.0.3</version>
+			<version>4.3.4</version>
 		</dependency>
 		<dependency>
 			<groupId>cglib</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<java-version>1.6</java-version>
-		<org.springframework-version>3.1.4.RELEASE</org.springframework-version>
+		<org.springframework-version>4.3.15.RELEASE</org.springframework-version>
 		<org.slf4j-version>1.5.10</org.slf4j-version>
 		<war.file.name>amenity-editor</war.file.name>
 
@@ -164,7 +164,7 @@
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>httpclient</artifactId>
-			<version>4.3.4</version>
+			<version>4.5.3</version>
 		</dependency>
 		<dependency>
 			<groupId>cglib</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,6 @@
 		<oauth.requestTokenEndpointUrl>http://api06.dev.openstreetmap.org/oauth/request_token</oauth.requestTokenEndpointUrl>
 		<oauth.accessTokenEndpointUrl>http://api06.dev.openstreetmap.org/oauth/access_token</oauth.accessTokenEndpointUrl>
 		<oauth.authorizeWebsiteUrl>http://api06.dev.openstreetmap.org/oauth/authorize</oauth.authorizeWebsiteUrl>
-
 	</properties>
 	<profiles>
 		<profile>
@@ -93,7 +92,6 @@
 				</exclusion>
 			</exclusions>
 		</dependency>
-
 		<!-- Logging -->
 		<dependency>
 			<groupId>org.slf4j</groupId>
@@ -133,7 +131,6 @@
 				</exclusion>
 			</exclusions>
 		</dependency>
-
 		<!-- Servlet -->
 		<dependency>
 			<groupId>javax.servlet</groupId>
@@ -152,7 +149,6 @@
 			<artifactId>jstl</artifactId>
 			<version>1.2</version>
 		</dependency>
-
 		<!-- Test -->
 		<dependency>
 			<groupId>junit</groupId>
@@ -160,7 +156,6 @@
 			<version>4.8.2</version>
 			<scope>test</scope>
 		</dependency>
-
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>httpclient</artifactId>
@@ -231,7 +226,6 @@
 			</snapshots>
 		</repository>
 	</repositories>
-
 	<distributionManagement>
 		<repository>
 			<id>maven.grundid.de</id>
@@ -246,7 +240,6 @@
 		<developerConnection>scm:git:ssh://git@github.com/grundid/amenity-editor.git</developerConnection>
 	</scm>
 	<build>
-	
 		<extensions>
 			<extension>
 				<groupId>org.apache.maven.wagon</groupId>
@@ -295,7 +288,6 @@
 					<schemaDirectory>src/main/schema</schemaDirectory>
 				</configuration>
 			</plugin>
-
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-war-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -184,7 +184,7 @@
 		<dependency>
 			<groupId>org.codehaus.jackson</groupId>
 			<artifactId>jackson-mapper-asl</artifactId>
-			<version>1.8.4</version>
+			<version>1.9.13</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.social</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<java-version>1.6</java-version>
 		<org.springframework-version>4.3.20.RELEASE</org.springframework-version>
-		<org.slf4j-version>1.5.10</org.slf4j-version>
+		<org.slf4j-version>1.7.29</org.slf4j-version>
 		<war.file.name>amenity-editor</war.file.name>
 
 		<db.driver>org.h2.Driver</db.driver>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<java-version>1.6</java-version>
-		<org.springframework-version>4.3.18.RELEASE</org.springframework-version>
+		<org.springframework-version>4.3.20.RELEASE</org.springframework-version>
 		<org.slf4j-version>1.5.10</org.slf4j-version>
 		<war.file.name>amenity-editor</war.file.name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -200,7 +200,7 @@
 		<dependency>
 			<groupId>com.h2database</groupId>
 			<artifactId>h2</artifactId>
-			<version>1.3.158</version>
+			<version>1.4.199</version>
 		</dependency>
 	</dependencies>
 	<repositories>


### PR DESCRIPTION
updated dependencies to fix 17 known vulnerabilities.

Here you need to upgrade the Spring framework, Apache HTTP components, and secure the access to localhost for the local editor.

There's still possibility of code injection in the XML parser (using malicious delerations in the DTD) when importing external XML data: the XML pserver should be secured by prohibiting custom DTD from external XML data. This allows remote code execution and access to arbitrary local files using custom named entities declared in the DTD, then using named entities in the XML data which is processeds by the local script outside the sandbox and possibly with the privbileges of the local administrator.

For XML OSM datafiles, we never need any custom DTD, so this should be disabled completely in the parser, so that such files will parse with an XML error and won't be imported.
